### PR TITLE
MAPRDB-920: Possibility to set logging in Python DB binding 

### DIFF
--- a/mapr/ojai/__init__.py
+++ b/mapr/ojai/__init__.py
@@ -1,0 +1,13 @@
+import logging
+
+
+def enable_debug_log(logger_name,
+                     logger_level=logging.DEBUG,
+                     logger_formatter='%(asctime)s - %(name)s - %(levelname)s - %(message)s'):
+    debug_logger = logging.getLogger(logger_name)
+    ch = logging.StreamHandler()
+    ch.setLevel(logger_level)
+    formatter = logging.Formatter(logger_formatter)
+    ch.setFormatter(formatter)
+    debug_logger.addHandler(ch)
+    debug_logger.setLevel(logging.DEBUG)

--- a/test/end_to_end_test/run_end_to_end.py
+++ b/test/end_to_end_test/run_end_to_end.py
@@ -1,3 +1,6 @@
+import logging
+
+from mapr.ojai import enable_debug_log
 from test.end_to_end_test.test_check_and_delete import CheckAndDeleteTest
 from test.end_to_end_test.test_check_and_replace import CheckAndReplaceTest
 from test.end_to_end_test.test_ddl_operations import ConnectionTest
@@ -25,6 +28,8 @@ if __name__ == '__main__':
                            ]
 
     loader = unittest.TestLoader()
+    enable_debug_log('mapr.ojai.storage',
+                     logger_level=logging.DEBUG)
 
     suites_list = []
     for test_class in test_classes_to_run:


### PR DESCRIPTION
Logging will be enabled if the method **enable_debug_log** was called.
```
import mapr
enable_debug_log()
```