### PR TITLE
Fix to clear temp document when processing a list 

### DIFF
--- a/mapr/ojai/ojai_utils/ojai_list.py
+++ b/mapr/ojai/ojai_utils/ojai_list.py
@@ -34,6 +34,7 @@ class OJAIList(list):
                     else:
                         internal_value = dump_document.set('dump', v).as_dictionary()['dump']
                         tmp_dict[k] = internal_value
+                        dump_document.clear()
                 ojai_list.append(tmp_dict)
             else:
                 ojai_list.append(dump_document.set('dump', elem).as_dictionary()['dump'])

--- a/test/document/test_document_with_tags.py
+++ b/test/document/test_document_with_tags.py
@@ -239,3 +239,16 @@ class DocumentTagsTest(unittest.TestCase):
                                                                  "surname": "Surname", "city": "City"}]}))
         self.assertEqual(doc.as_json_str(with_tags=False),
                          json.dumps({"_id": "some_id", "list": [{"name": 55, "surname": "Surname", "city": "City"}]}))
+
+    def test_list_with_nested_complex_dicts(self):
+        test_doc_dict = {"_id": "some_id", "list": [{"age": 55,
+                                                     "name": {"surname": "Surname",
+                                                              "firstname": "firstname"}}]}
+        doc = OJAIDocument().from_dict(test_doc_dict)
+        self.assertEqual(doc.as_dictionary(),
+                         {'_id': 'some_id', 'list': [{'age': 55, "name": {'firstname': 'firstname', 'surname': 'Surname'}}]})
+        self.assertEqual(doc.as_json_str(),
+                         json.dumps({"_id": "some_id", "list": [{"age": {"$numberLong": 55},
+                                                                 "name": {"surname": "Surname", "firstname": "firstname"}}]}))
+        self.assertEqual(doc.as_json_str(with_tags=False),
+                         json.dumps({"_id": "some_id", "list": [{"age": 55, "name": {"surname": "Surname", "firstname": "firstname"}}]}))


### PR DESCRIPTION
prevents elements being reproduced in subsequent nested elements.

Closes #63