### PR TITLE
MAPRDB-2646: "maprdb-python-client' repeatedly use "basic" auth even …

### DIFF
--- a/mapr/ojai/storage/auth_interceptor.py
+++ b/mapr/ojai/storage/auth_interceptor.py
@@ -49,7 +49,6 @@ class __UserMetadata(object):
             value = 'basic {0}'.format(self._encoded_user_creds)
         else:
             value = 'bearer {0}'.format(self._token)
-            self._token = None
         return 'authorization', value
 
     def set_jwt_token(self, call, stream=False):


### PR DESCRIPTION
…after acquiring JWT